### PR TITLE
Improve stable of gluing multi-lines

### DIFF
--- a/rapydml/compiler.py
+++ b/rapydml/compiler.py
@@ -1089,10 +1089,11 @@ class Parser:
 				line_num += 1
 				try:
 					#parse multi-lines together
-					if line[-2:] == '\\\n':
+					#ignore extra spaces after '\' at the line end 
+					if line.rstrip()[-1:] == '\\':
 						if buffer:
 							line = ' ' + line.lstrip()
-						buffer += line[:-2]
+						buffer += line.rstrip()[:-1]
 						continue
 					elif buffer:
 						line = buffer + ' ' + line.lstrip()


### PR DESCRIPTION
Improve stable of gluing multi-lines by ignoring extra spaces after '\\' at the line end, 
i.e.  now  ` '   \      \n'   ==   '   \\n'`